### PR TITLE
TMDB content ratings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.uwetrottmann.tmdb2</groupId>
 			<artifactId>tmdb-java</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/tinymediamanager/scraper/tmdb/TmdbTvShowMetadataProvider.java
+++ b/src/main/java/org/tinymediamanager/scraper/tmdb/TmdbTvShowMetadataProvider.java
@@ -26,6 +26,7 @@ import org.tinymediamanager.scraper.MediaMetadata;
 import org.tinymediamanager.scraper.MediaScrapeOptions;
 import org.tinymediamanager.scraper.MediaSearchOptions;
 import org.tinymediamanager.scraper.MediaSearchResult;
+import org.tinymediamanager.scraper.entities.Certification;
 import org.tinymediamanager.scraper.entities.MediaArtwork;
 import org.tinymediamanager.scraper.entities.MediaArtwork.MediaArtworkType;
 import org.tinymediamanager.scraper.entities.MediaCastMember;
@@ -37,6 +38,7 @@ import org.tinymediamanager.scraper.util.MetadataUtil;
 import com.uwetrottmann.tmdb2.Tmdb;
 import com.uwetrottmann.tmdb2.entities.AppendToResponse;
 import com.uwetrottmann.tmdb2.entities.CastMember;
+import com.uwetrottmann.tmdb2.entities.ContentRating;
 import com.uwetrottmann.tmdb2.entities.ProductionCompany;
 import com.uwetrottmann.tmdb2.entities.TvEpisode;
 import com.uwetrottmann.tmdb2.entities.TvResultsPage;
@@ -231,8 +233,10 @@ class TmdbTvShowMetadataProvider {
     TvShowComplete complete = null;
     synchronized (api) {
       TmdbConnectionCounter.trackConnections();
-      complete = api.tvService().tv(tmdbId, language, new AppendToResponse(AppendToResponseItem.CREDITS, AppendToResponseItem.EXTERNAL_IDS)).execute()
-          .body();
+      complete = api.tvService()
+          .tv(tmdbId, language,
+              new AppendToResponse(AppendToResponseItem.CREDITS, AppendToResponseItem.EXTERNAL_IDS, AppendToResponseItem.CONTENT_RATINGS))
+          .execute().body();
     }
 
     if (complete == null) {
@@ -287,6 +291,21 @@ class TmdbTvShowMetadataProvider {
     // if (complete.external_ids != null && complete.external_ids.tvrage_id!= null) {
     // md.setId(MediaMetadata.TV_RAGE, complete.external_ids.tvdb_id);
     // }
+
+    // content ratings
+    if (complete.content_ratings != null) {
+      for (ContentRating country : ListUtils.nullSafe(complete.content_ratings.results)) {
+        if (options.getCountry() == null || options.getCountry().getAlpha2().compareToIgnoreCase(country.iso_3166_1) == 0) {
+          // do not use any empty certifications
+          if (StringUtils.isEmpty(country.rating)) {
+            continue;
+          }
+
+          md.addCertification(Certification.getCertification(country.iso_3166_1, country.rating));
+
+        }
+      }
+    }
 
     return md;
   }

--- a/src/test/java/org/tinymediamanager/scraper/tmdb/TmdbMetadataProviderTest.java
+++ b/src/test/java/org/tinymediamanager/scraper/tmdb/TmdbMetadataProviderTest.java
@@ -13,6 +13,7 @@ import org.tinymediamanager.scraper.MediaMetadata;
 import org.tinymediamanager.scraper.MediaScrapeOptions;
 import org.tinymediamanager.scraper.MediaSearchOptions;
 import org.tinymediamanager.scraper.MediaSearchResult;
+import org.tinymediamanager.scraper.entities.Certification;
 import org.tinymediamanager.scraper.entities.CountryCode;
 import org.tinymediamanager.scraper.entities.MediaCastMember.CastType;
 import org.tinymediamanager.scraper.entities.MediaEpisode;
@@ -385,6 +386,7 @@ public class TmdbMetadataProviderTest {
       assertNotEquals(0, (int) md.getVoteCount());
       assertEquals("Ended", md.getStatus());
       assertThat(md.getProductionCompanies()).isNotEmpty();
+      assertEquals(Certification.US_TVPG, md.getCertifications().get(0));
     }
     catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
Hello again,

This new pull request adds support for getting content-ratings/certification information about TV Shows from themoviedb.org

In the end it turned out tmdb-java didn't support content ratings either so I submitted some changes to that project forcing the need for an uprev to 1.1.0 on the dependency.

I added to the existing test case and the tests are still passing.